### PR TITLE
Fix javascript text typos

### DIFF
--- a/resources/public/js/audit-failure-detection.js
+++ b/resources/public/js/audit-failure-detection.js
@@ -48,7 +48,7 @@ $(document).ready(function() {
       var moreInfo = "";
       moreInfo += '<div>Detected: ' + audit.RecoveryStartTimestamp + '</div>';
       if (audit.AnalysisEntry.SlaveHosts.length > 0) {
-        moreInfo += '<div>' + audit.AnalysisEntry.CountReplicas + ' replicting hosts :<ul>';
+        moreInfo += '<div>' + audit.AnalysisEntry.CountReplicas + ' replicating hosts :<ul>';
         audit.AnalysisEntry.SlaveHosts.forEach(function(instanceKey) {
           moreInfo += "<li><code>" + getInstanceTitle(instanceKey.Hostname, instanceKey.Port) + "</code></li>";
         });

--- a/resources/public/js/audit-recovery.js
+++ b/resources/public/js/audit-recovery.js
@@ -96,7 +96,7 @@ $(document).ready(function() {
         moreInfo += "</ul></div>";
       }
       if (audit.AnalysisEntry.SlaveHosts.length > 0) {
-        moreInfo += '<div>' + audit.AnalysisEntry.CountReplicas + ' replicting hosts :<ul>';
+        moreInfo += '<div>' + audit.AnalysisEntry.CountReplicas + ' replicating hosts :<ul>';
         audit.AnalysisEntry.SlaveHosts.forEach(function(instanceKey) {
           moreInfo += "<li><code>" + getInstanceTitle(instanceKey.Hostname, instanceKey.Port) + "</code></li>";
         });


### PR DESCRIPTION
Tiny patch which catches a couple of typos in web/audit-recovery and elsewhere.